### PR TITLE
Fix min system req

### DIFF
--- a/Build/osx-x64/Info.plist
+++ b/Build/osx-x64/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.12</string>
+	<string>10.13</string>
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>x86_64</string>


### PR DESCRIPTION
From dotnet core 3.0 macOS 10.13 is the minumum. https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?tabs=netcore31&pivots=os-macos