### PR TITLE
Revert "Add dotnet6.0 runtime deps to debian control file (Fix #45)"

### DIFF
--- a/Build/debian-x64/control
+++ b/Build/debian-x64/control
@@ -7,6 +7,5 @@ Vcs-Git: git://github.com/btcpayserver/BTCPayServer.Vault.git
 Vcs-Browser: https://github.com/btcpayserver/BTCPayServer.Vault
 Architecture: amd64
 License: Open Source (MIT)
-Depends: libgcc1, libicu | libicu72 | libicu71 | libicu70 | libicu69 | libicu68 | libicu67 | libicu66 | libicu65 | libicu63 | libicu60 | libicu57 | libicu55 | libicu52, libc6, libssl1.0.0 | libssl1.0.2 | libssl1.1 | libssl3, zlib1g, libstdc++6, libgssapi-krb5-2
 Installed-Size: {SIZEINKB}
 Description: {DESCRIPTION}


### PR DESCRIPTION
Reverts btcpayserver/BTCPayServer.Vault#47