### PR TITLE
build: add macos arm64 vault release

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,6 +44,15 @@ jobs:
         env:
           RID: osx-x64
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
+  osx-arm64:
+    name: osx-arm64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./Build/CI/build.sh
+        env:
+          RID: osx-arm64
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
   win-x64:
     name: win-x64
     runs-on: ubuntu-latest
@@ -58,7 +67,7 @@ jobs:
   applesign:
     name: applesign
     runs-on: macOS-latest
-    needs: [osx-x64]
+    needs: [osx-x64, osx-arm64]
     if: startsWith( github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +82,7 @@ jobs:
   pgpsign:
     name: pgpsign
     runs-on: ubuntu-latest
-    needs: [win-x64, osx-x64, linux-x64, debian-x64, applesign]
+    needs: [win-x64, osx-x64, osx-arm64, linux-x64, debian-x64, applesign]
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v4
@@ -92,4 +101,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
-  

--- a/Build/CI/applesign.sh
+++ b/Build/CI/applesign.sh
@@ -43,26 +43,14 @@ version="$(cat BTCPayServer.Vault/Version.csproj | sed -n 's/.*<Version>\(.*\)<\
 title="$(cat BTCPayServer.Vault/BTCPayServer.Vault.csproj | sed -n 's/.*<Title>\(.*\)<\/Title>.*/\1/p')"
 AZURE_ACCOUNT_NAME="$(echo "$AZURE_STORAGE_CONNECTION_STRING" | cut -d'=' -f3 | cut -d';' -f1)"
 DIRECTORY_NAME="dist-$GITHUB_RUN_ID"
-RUNTIME="osx-x64"
-tar_file="BTCPayServerVault-${RUNTIME}-$version.tar.gz"
+MACOS_RUNTIMES=("osx-x64" "osx-arm64")
 
 mkdir -p dist
-download_url="https://$AZURE_ACCOUNT_NAME.blob.core.windows.net/$AZURE_STORAGE_CONTAINER/$DIRECTORY_NAME/$tar_file"
-echo "Download $download_url to dist/$tar_file"
-wget -qO "dist/$tar_file" "$download_url"
-echo "Downloaded"
 cd dist
 if ! (echo "$APPLE_DEV_ID_CERT" | base64 --decode > dev.p12); then
     echo "Could not decode APPLE_DEV_ID_CERT from base64"
     exit 1
 fi
-
-dmg_folder="dmg_root"
-app_path="$dmg_folder/$title.app"
-mkdir -p "$dmg_folder"
-tar -C "$dmg_folder" -xvf "$tar_file"
-bundle_id="$(cat "$app_path/Contents/Info.plist" | grep -A1 "CFBundleIdentifier" | sed -n 's/\s*<string>\([^<]*\)<\/string>/\1/p' | xargs)"
-rm "$tar_file"
 
 key_chain="build.keychain"
 key_chain_pass="mysecretpassword"
@@ -74,39 +62,60 @@ CERT_IDENTITY=$(security find-identity -v -p codesigning "$key_chain" | head -1 
 echo "Signing with identity $CERT_IDENTITY"
 security set-key-partition-list -S apple-tool:,apple: -s -k "$key_chain_pass" "$key_chain"
 
-# codesign don't like that the entitlements file path have spaces, so we move it to local folder.
-sudo cp "$app_path/Contents/entitlements.plist" "./"
-echo "Signing $app_path..."
 code_sign_args="--deep --force --options runtime --timestamp --entitlements entitlements.plist"
-sudo codesign $code_sign_args --sign "$CERT_IDENTITY" "$app_path"
-
-dmg_file="BTCPayServerVault-${RUNTIME}-$version.dmg"
-echo "Create $dmg_file with signature"
-dmg_file_writable="$dmg_file.writable.dmg"
-sudo hdiutil create "$dmg_file_writable" -ov -volname "$title" -fs HFS+ -srcfolder "$dmg_folder" 
-sudo hdiutil convert "$dmg_file_writable" -format UDZO -o "$dmg_file"
-sudo rm -rf "$dmg_file_writable"
-rm -rf "$dmg_folder"
-
-echo "Signing $dmg_file..."
-sudo codesign $code_sign_args --sign "$CERT_IDENTITY" "$dmg_file"
-echo "DMG signed"
-
-echo "Notarize $dmg_file with bundle id $bundle_id"
-
-sudo xcrun notarytool submit --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait "$dmg_file"
-
-sudo xcrun stapler staple "$dmg_file"
 
 echo "Installing az..."
 export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
 brew update
 brew install azure-cli || true
-BLOB_NAME="$DIRECTORY_NAME/$dmg_file"
-echo "Uploading $BLOB_NAME"
-sudo az storage blob upload -f "$dmg_file" --connection-string "$AZURE_STORAGE_CONNECTION_STRING" -c "$AZURE_STORAGE_CONTAINER" -n "$BLOB_NAME"
-url="$(sudo az storage blob url --connection-string "$AZURE_STORAGE_CONNECTION_STRING" --container-name "$AZURE_STORAGE_CONTAINER" --name "$BLOB_NAME" --protocol "https")"
-echo "Uploaded file to $url"
 
-echo "Deleting $DIRECTORY_NAME/$tar_file"
-sudo az storage blob delete --connection-string "$AZURE_STORAGE_CONNECTION_STRING" -c "$AZURE_STORAGE_CONTAINER" -n "$DIRECTORY_NAME/$tar_file"
+for RUNTIME in "${MACOS_RUNTIMES[@]}"; do
+    tar_file="BTCPayServerVault-${RUNTIME}-$version.tar.gz"
+    download_url="https://$AZURE_ACCOUNT_NAME.blob.core.windows.net/$AZURE_STORAGE_CONTAINER/$DIRECTORY_NAME/$tar_file"
+    echo "Download $download_url to $tar_file"
+    wget -qO "$tar_file" "$download_url"
+    echo "Downloaded"
+
+    dmg_folder="dmg_root_$RUNTIME"
+    app_path="$dmg_folder/$title.app"
+    rm -rf "$dmg_folder"
+    mkdir -p "$dmg_folder"
+    tar -C "$dmg_folder" -xvf "$tar_file"
+    bundle_id="$(cat "$app_path/Contents/Info.plist" | grep -A1 "CFBundleIdentifier" | sed -n 's/\s*<string>\([^<]*\)<\/string>/\1/p' | xargs)"
+    rm "$tar_file"
+
+    # codesign don't like that the entitlements file path have spaces, so we move it to local folder.
+    sudo cp "$app_path/Contents/entitlements.plist" "./"
+    echo "Signing $app_path..."
+    sudo codesign $code_sign_args --sign "$CERT_IDENTITY" "$app_path"
+
+    dmg_file="BTCPayServerVault-${RUNTIME}-$version.dmg"
+    echo "Create $dmg_file with signature"
+    dmg_file_writable="$dmg_file.writable.dmg"
+    sudo hdiutil create "$dmg_file_writable" -ov -volname "$title" -fs HFS+ -srcfolder "$dmg_folder"
+    sudo hdiutil convert "$dmg_file_writable" -format UDZO -o "$dmg_file"
+    sudo rm -rf "$dmg_file_writable"
+    rm -rf "$dmg_folder"
+
+    echo "Signing $dmg_file..."
+    sudo codesign $code_sign_args --sign "$CERT_IDENTITY" "$dmg_file"
+    echo "DMG signed"
+
+    echo "Notarize $dmg_file with bundle id $bundle_id"
+
+    sudo xcrun notarytool submit --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait "$dmg_file"
+
+    sudo xcrun stapler staple "$dmg_file"
+
+    BLOB_NAME="$DIRECTORY_NAME/$dmg_file"
+    echo "Uploading $BLOB_NAME"
+    sudo az storage blob upload -f "$dmg_file" --connection-string "$AZURE_STORAGE_CONNECTION_STRING" -c "$AZURE_STORAGE_CONTAINER" -n "$BLOB_NAME" --overwrite true
+    url="$(sudo az storage blob url --connection-string "$AZURE_STORAGE_CONNECTION_STRING" --container-name "$AZURE_STORAGE_CONTAINER" --name "$BLOB_NAME" --protocol "https")"
+    echo "Uploaded file to $url"
+done
+
+for RUNTIME in "${MACOS_RUNTIMES[@]}"; do
+    tar_file="BTCPayServerVault-${RUNTIME}-$version.tar.gz"
+    echo "Deleting $DIRECTORY_NAME/$tar_file"
+    sudo az storage blob delete --connection-string "$AZURE_STORAGE_CONNECTION_STRING" -c "$AZURE_STORAGE_CONTAINER" -n "$DIRECTORY_NAME/$tar_file"
+done

--- a/Build/CI/build.sh
+++ b/Build/CI/build.sh
@@ -4,14 +4,19 @@ set -e
 
 DOCKER_IMAGE_NAME="vault-$RID"
 DOCKER_BUILD_ARGS=""
+DOCKERFILE="Build/$RID/Dockerfile"
 if [[ "$PGP_KEY" ]]; then
      DOCKER_BUILD_ARGS="--build-arg "PGP_KEY=$PGP_KEY""
 fi
 if [[ "$WINDOWS_CERT" ]]; then
      DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg "WINDOWS_CERT=$WINDOWS_CERT" --build-arg "WINDOWS_CERT_PASSWORD=$WINDOWS_CERT_PASSWORD""
 fi
+if [[ "$RID" == "osx-arm64" ]]; then
+     DOCKERFILE="Build/osx-x64/Dockerfile"
+     DOCKER_BUILD_ARGS="$DOCKER_BUILD_ARGS --build-arg RUNTIME=osx-arm64 --build-arg HWI_PACKAGE_ARCH=arm64 --build-arg HWI_SHA256=87a8991848a0216213ddf6497c753cebbda492626afaf5608c30931155c922c3 --build-arg ARCHITECTURE_PRIORITY=arm64"
+fi
 
-docker build -t "$DOCKER_IMAGE_NAME" $DOCKER_BUILD_ARGS -f "Build/$RID/Dockerfile" .
+docker build -t "$DOCKER_IMAGE_NAME" $DOCKER_BUILD_ARGS -f "$DOCKERFILE" .
 docker run --rm -v "$(pwd)/dist:/opt/dist" "$DOCKER_IMAGE_NAME"
 
 if [[ "$GITHUB_REF" ]]; then

--- a/Build/common/export-variables.sh
+++ b/Build/common/export-variables.sh
@@ -4,7 +4,9 @@ DOTNET_RUNTIME=${DOTNET_RUNTIME:-$RUNTIME}
 BUILD_ARGS="--runtime $DOTNET_RUNTIME -p:Configuration=Release -p:GithubDistrib=true"
 FRAMEWORK="net10.0"
 DIST="/source/dist"
-RESOURCES="/source/Build/${RUNTIME}"
+RESOURCE_RUNTIME=${RESOURCE_RUNTIME:-$RUNTIME}
+ARCHITECTURE_PRIORITY=${ARCHITECTURE_PRIORITY:-x86_64}
+RESOURCES="/source/Build/${RESOURCE_RUNTIME}"
 RESOURCES_COMMON="/source/Build/common"
 RESOURCES_LINUX="/source/Build/linux-x64"
 PROJECT_FILE="/source/BTCPayServer.Vault/BTCPayServer.Vault.csproj"
@@ -29,6 +31,7 @@ replaceProjectVariables () {
   sed -i "s/{DESCRIPTION}/$DESCRIPTION/g" "$1"
   sed -i "s/{EXECUTABLE}/$EXECUTABLE/g" "$1"
   sed -i "s/{COMPANY}/$COMPANY/g" "$1"
+  sed -i "s/{ArchitecturePriority}/$ARCHITECTURE_PRIORITY/g" "$1"
 }
 
 dotnet_publish () {

--- a/Build/osx-x64/Dockerfile
+++ b/Build/osx-x64/Dockerfile
@@ -1,5 +1,11 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS builder
 
+ARG RUNTIME=osx-x64
+ARG RESOURCE_RUNTIME=osx-x64
+ARG HWI_PACKAGE_ARCH=x86_64
+ARG HWI_SHA256=b3764a530b635e7a7348c9185e09e74b389f5f585094fe316f700eec7c761875
+ARG ARCHITECTURE_PRIORITY=x86_64
+
 # Optimize docker cache, do not make it one layer
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends imagemagick
@@ -7,15 +13,17 @@ RUN apt-get install -y --no-install-recommends imagemagick
 
 RUN apt-get install -y --no-install-recommends git icnsutils
 
-RUN wget -qO /tmp/hwi.tar.gz https://github.com/bitcoin-core/HWI/releases/download/3.2.0/hwi-3.2.0-mac-x86_64.tar.gz && \
+RUN wget -qO /tmp/hwi.tar.gz "https://github.com/bitcoin-core/HWI/releases/download/3.2.0/hwi-3.2.0-mac-${HWI_PACKAGE_ARCH}.tar.gz" && \
     tar -zxvf /tmp/hwi.tar.gz -C /tmp hwi && \
-    echo "b3764a530b635e7a7348c9185e09e74b389f5f585094fe316f700eec7c761875 /tmp/hwi" | sha256sum -c - && \
+    echo "$HWI_SHA256 /tmp/hwi" | sha256sum -c - && \
     rm /tmp/hwi.tar.gz
 
 WORKDIR /source
-ENV RUNTIME "osx-x64"
+ENV RUNTIME=$RUNTIME
+ENV RESOURCE_RUNTIME=$RESOURCE_RUNTIME
+ENV ARCHITECTURE_PRIORITY=$ARCHITECTURE_PRIORITY
 COPY "Build/common" "Build/common"
-ENV EXPORT_VARIABLES "source Build/common/export-variables.sh"
+ENV EXPORT_VARIABLES="source Build/common/export-variables.sh"
 COPY BTCPayServer.Vault/BTCPayServer.Vault.csproj BTCPayServer.Vault/BTCPayServer.Vault.csproj
 COPY BTCPayServer.Hwi/BTCPayServer.Hwi.csproj BTCPayServer.Hwi/BTCPayServer.Hwi.csproj
 
@@ -25,7 +33,7 @@ COPY BTCPayServer.Hwi BTCPayServer.Hwi
 COPY BTCPayServer.Vault BTCPayServer.Vault
 RUN $EXPORT_VARIABLES && dotnet_publish && mv /tmp/hwi "$PUBLISH_FOLDER/"
 
-COPY "Build/${RUNTIME}" "Build/${RUNTIME}"
+COPY "Build/${RESOURCE_RUNTIME}" "Build/${RESOURCE_RUNTIME}"
 COPY BTCPayServerVault.png BTCPayServerVault.png
 RUN $EXPORT_VARIABLES && \
     replaceProjectVariables "$RESOURCES/Info.plist" && \

--- a/Build/osx-x64/Info.plist
+++ b/Build/osx-x64/Info.plist
@@ -6,7 +6,7 @@
 	<string>10.13</string>
 	<key>LSArchitecturePriority</key>
 	<array>
-		<string>x86_64</string>
+		<string>{ArchitecturePriority}</string>
 	</array>
 	<key>CFBundleIconFile</key>
 	<string>BTCPayServerVault.icns</string>

--- a/docs/HowToVerify.md
+++ b/docs/HowToVerify.md
@@ -75,6 +75,8 @@ You should see that the file you downloaded has the right hash:
 BTCPayServerVault-osx-x64-1.0.7.dmg: OK
 ```
 
+On Apple Silicon Macs, use the `osx-arm64` DMG instead of the `osx-x64` DMG.
+
 Then check the actual signature:
 
 ```bash


### PR DESCRIPTION
This adds a native macOS arm64 release artifact for BTCPay Server Vault.

macOS now warns that support is ending for Intel-based apps on Apple Silicon Macs. The existing macOS Vault release is `osx-x64`, and its app bundle includes Intel-only components. This PR adds an `osx-arm64` DMG so Apple Silicon users have a native build path before future macOS releases stop supporting those Intel-based components.

Changes:
- Add an `osx-arm64` macOS build target.
- Bundle the arm64 HWI binary for the arm64 app.
- Build, sign, notarize, and upload both `osx-x64` and `osx-arm64` DMGs.
- Document that Apple Silicon users should use the `osx-arm64` DMG.

<img width="353" height="107" alt="btcpay-vault" src="https://github.com/user-attachments/assets/970c27ed-1c68-4788-a862-2dd6bef2643e" />
